### PR TITLE
Update base image

### DIFF
--- a/v4.16/Dockerfile
+++ b/v4.16/Dockerfile
@@ -1,6 +1,6 @@
 # The base image is expected to contain
 # /bin/opm (with a serve subcommand) and /bin/grpc_health_probe
-FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.16
+FROM registry.redhat.io/openshift4/ose-operator-registry-rhel9:v4.16
 
 # Configure the entrypoint and command
 ENTRYPOINT ["/bin/opm"]


### PR DESCRIPTION
Use the base image required by the entrprise contract.

Docs: https://konflux-ci.dev/architecture/ADR/0026-specifying-ocp-targets-for-fbc.html