### PR TITLE
tekton: build a single arch

### DIFF
--- a/.tekton/pipeline.yaml
+++ b/.tekton/pipeline.yaml
@@ -7,7 +7,7 @@ spec:
   - name: show-sbom
     params:
     - name: IMAGE_URL
-      value: $(tasks.build-image-index.results.IMAGE_URL)
+      value: $(tasks.build-container.results.IMAGE_URL)
     taskRef:
       params:
       - name: name
@@ -26,7 +26,7 @@ spec:
     - name: image-url
       value: $(params.output-image)
     - name: build-task-status
-      value: $(tasks.build-image-index.status)
+      value: $(tasks.build-container.status)
     taskRef:
       params:
       - name: name
@@ -68,13 +68,17 @@ spec:
     description: Skip checks against built image
     name: skip-checks
     type: string
-  - default: "true"
+  - default: "false"
     description: Execute the build with network isolation
     name: hermetic
     type: string
   - default: ""
     description: Build dependencies to be prefetched by Cachi2
     name: prefetch-input
+    type: string
+  - default: "false"
+    description: Java build
+    name: java
     type: string
   - default: ""
     description: Image tag expiration time, time values could be something like
@@ -84,24 +88,19 @@ spec:
     description: Build a source image.
     name: build-source-image
     type: string
-  - default: "true"
-    description: Add built image into an OCI image index
-    name: build-image-index
-    type: string
   - default:
     - linux/x86_64
-    - linux/arm64
-    description: List of platforms to build the container images on. The available
-      set of values is determined by the configuration of the multi-platform-controller.
+    description: Ignored in the single-arch pipeline.
+      Provided for compatibility with multi-arch PipelineRuns.
     name: build-platforms
     type: array
   results:
   - description: ""
     name: IMAGE_URL
-    value: $(tasks.build-image-index.results.IMAGE_URL)
+    value: $(tasks.build-container.results.IMAGE_URL)
   - description: ""
     name: IMAGE_DIGEST
-    value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    value: $(tasks.build-container.results.IMAGE_DIGEST)
   - description: ""
     name: CHAINS-GIT_URL
     value: $(tasks.clone-repository.results.url)
@@ -132,18 +131,14 @@ spec:
       value: $(params.git-url)
     - name: revision
       value: $(params.revision)
-    - name: ociStorage
-      value: $(params.output-image).git
-    - name: ociArtifactExpiresAfter
-      value: $(params.image-expires-after)
     runAfter:
     - init
     taskRef:
       params:
       - name: name
-        value: git-clone-oci-ta
+        value: git-clone
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:b03bb5e21665b17ae2f645496013a072b00f1a174024dc1ff41dc626f364c66b
+        value: quay.io/konflux-ci/tekton-catalog/task-git-clone:0.1@sha256:0bb1be8363557e8e07ec34a3c5daaaaa23c9d533f0bb12f00dc604d00de50814
       - name: kind
         value: task
       resolver: bundles
@@ -153,14 +148,11 @@ spec:
       values:
       - "true"
     workspaces:
+    - name: output
+      workspace: workspace
     - name: basic-auth
       workspace: git-auth
-  - matrix:
-      params:
-      - name: PLATFORM
-        value:
-        - $(params.build-platforms)
-    name: build-images
+  - name: build-container
     params:
     - name: IMAGE
       value: $(params.output-image)
@@ -169,23 +161,19 @@ spec:
     - name: CONTEXT
       value: $(params.path-context)
     - name: HERMETIC
-      value: $(params.hermetic)
+      value: "true"
     - name: IMAGE_EXPIRES_AFTER
       value: $(params.image-expires-after)
     - name: COMMIT_SHA
       value: $(tasks.clone-repository.results.commit)
-    - name: SOURCE_ARTIFACT
-      value: $(tasks.clone-repository.results.SOURCE_ARTIFACT)
-    - name: IMAGE_APPEND_PLATFORM
-      value: "true"
     runAfter:
     - clone-repository
     taskRef:
       params:
       - name: name
-        value: buildah-remote-oci-ta
+        value: buildah
       - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:50f7af0eafcd38919aa217b32b2bffffc04629b50dc1fe51b5f2215934eb6344
+        value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:71d3bb81d1c7c9f99946b5f1d4844664f2036636fd114cf5232db644bc088981
       - name: kind
         value: task
       resolver: bundles
@@ -194,43 +182,17 @@ spec:
       operator: in
       values:
       - "true"
-  - name: build-image-index
-    params:
-    - name: IMAGE
-      value: $(params.output-image)
-    - name: COMMIT_SHA
-      value: $(tasks.clone-repository.results.commit)
-    - name: IMAGE_EXPIRES_AFTER
-      value: $(params.image-expires-after)
-    - name: ALWAYS_BUILD_INDEX
-      value: $(params.build-image-index)
-    - name: IMAGES
-      value:
-      - $(tasks.build-images.results.IMAGE_REF[*])
-    runAfter:
-    - build-images
-    taskRef:
-      params:
-      - name: name
-        value: build-image-index
-      - name: bundle
-        value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.1@sha256:8619eabd7cf3340d1123afadac1f4296dc14472c8db0f774497748c762f46f33
-      - name: kind
-        value: task
-      resolver: bundles
-    when:
-    - input: $(tasks.init.results.build)
-      operator: in
-      values:
-      - "true"
+    workspaces:
+    - name: source
+      workspace: workspace
   - name: deprecated-base-image-check
     params:
     - name: IMAGE_URL
-      value: $(tasks.build-image-index.results.IMAGE_URL)
+      value: $(tasks.build-container.results.IMAGE_URL)
     - name: IMAGE_DIGEST
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
     runAfter:
-    - build-image-index
+    - build-container
     taskRef:
       params:
       - name: name
@@ -248,9 +210,9 @@ spec:
   - name: apply-tags
     params:
     - name: IMAGE
-      value: $(tasks.build-image-index.results.IMAGE_URL)
+      value: $(tasks.build-container.results.IMAGE_URL)
     runAfter:
-    - build-image-index
+    - build-container
     taskRef:
       params:
       - name: name
@@ -260,14 +222,38 @@ spec:
       - name: kind
         value: task
       resolver: bundles
+  - name: push-dockerfile
+    params:
+    - name: IMAGE
+      value: $(tasks.build-container.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
+    - name: DOCKERFILE
+      value: $(params.dockerfile)
+    - name: CONTEXT
+      value: $(params.path-context)
+    runAfter:
+    - build-container
+    taskRef:
+      params:
+      - name: name
+        value: push-dockerfile
+      - name: bundle
+        value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile:0.1@sha256:0d2b6d31dc8bc02c5493d7d28a163bb6c867be5f86c3a82388b0d5c69e18d352
+      - name: kind
+        value: task
+      resolver: bundles
+    workspaces:
+    - name: workspace
+      workspace: workspace
   - name: inspect-image
     params:
     - name: IMAGE_URL
-      value: $(tasks.build-image-index.results.IMAGE_URL)
+      value: $(tasks.build-container.results.IMAGE_URL)
     - name: IMAGE_DIGEST
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
     runAfter:
-    - build-image-index
+    - build-container
     taskRef:
       params:
       - name: name
@@ -288,9 +274,9 @@ spec:
   - name: fbc-validate
     params:
     - name: IMAGE_URL
-      value: $(tasks.build-image-index.results.IMAGE_URL)
+      value: $(tasks.build-container.results.IMAGE_URL)
     - name: IMAGE_DIGEST
-      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+      value: $(tasks.build-container.results.IMAGE_DIGEST)
     - name: BASE_IMAGE
       value: $(tasks.inspect-image.results.BASE_IMAGE)
     runAfter:


### PR DESCRIPTION
This is a workaround to release x86-64 while we wait for Konflux to support the multi-arch image in the FBC release pipeline.