### PR TITLE
test-fbc: add the files needed to build a test catalog

### DIFF
--- a/test-fbc/Dockerfile
+++ b/test-fbc/Dockerfile
@@ -1,0 +1,31 @@
+# The builder image is expected to contain
+# /bin/opm (with serve subcommand)
+FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19 as builder
+USER root
+
+RUN dnf install -y go && go install github.com/mikefarah/yq/v4@v4.35.1
+
+WORKDIR /workdir
+ADD render.sh icon.png ./
+COPY test-fbc ./test-fbc
+
+RUN mkdir -p test-fbc/catalog/trustee-operator && PATH=/root/go/bin:$PATH ./render.sh test-fbc
+
+# Copy FBC root into image at /configs and pre-populate serve cache
+RUN cp -r test-fbc/catalog/ /configs
+RUN ["/bin/opm", "serve", "/configs", "--cache-dir=/tmp/cache", "--cache-only"]
+
+FROM brew.registry.redhat.io/rh-osbs/openshift-ose-operator-registry-rhel9:v4.19
+# The base image is expected to contain
+# /bin/opm (with serve subcommand) and /bin/grpc_health_probe
+
+# Configure the entrypoint and command
+ENTRYPOINT ["/bin/opm"]
+CMD ["serve", "/configs", "--cache-dir=/tmp/cache"]
+
+COPY --from=builder /configs /configs
+COPY --from=builder /tmp/cache /tmp/cache
+
+# Set FBC-specific label for the location of the FBC root directory
+# in the image
+LABEL operators.operatorframework.io.index.configs.v1=/configs

--- a/test-fbc/catalog-template.yaml
+++ b/test-fbc/catalog-template.yaml
@@ -1,0 +1,18 @@
+---
+entries:
+  - defaultChannel: stable
+    icon:
+      base64data: ""
+      mediatype: image/png
+    name: trustee-operator
+    schema: olm.package
+  - entries:
+      - name: trustee-operator.v0.4.1
+        replaces: trustee-operator.v0.4.0
+        skipRange: '>=0.1.0 <0.2.0'
+    name: stable
+    package: trustee-operator
+    schema: olm.channel
+  - image: registry.redhat.io/build-of-trustee/trustee-operator-bundle@sha256:6a4583e33d595c560c0618879ac6b3b085b33f55767b08aa80e0a4f44221acd2
+    schema: olm.bundle
+schema: olm.template.basic


### PR DESCRIPTION
This commit adds a new catalog for trustee-operator, that contains only the latest bundle reference.
We will create a nudge relationship between the bundle image and this test-fbc component in Konflux, so that everytime a new bundle is built, this unique reference is updated.
The Dockerfile for this test-fbc then runs our render.sh script, looking for the related images for the referenced bundle, and generating the catalog.json file at build time.

This means that merging the nudge PR will automatically produce a catalog that can be used on all versions of OCP.
It makes it easier to create a testable catalog for new builds. Using specific tags on the catalog will also help identify what builds were tested whenever a bug is reported.
Hopefully, this standardization should help with test automation.

Note that as the build of this catalog requires network access, it makes this catalog unreleasable, as we can't build it hermetically.

This is meant to address https://issues.redhat.com/browse/TRUSTEE-9

It is possible to test it before merging by running the following (from the root of the repository):
```
$ podman build . -f test-fbc/Dockerfile
```