### PR TITLE
chore(deps): update trustee-operator-bundle and nudge test catalog build

### DIFF
--- a/test-fbc/catalog-template.yaml
+++ b/test-fbc/catalog-template.yaml
@@ -7,12 +7,12 @@ entries:
     name: trustee-operator
     schema: olm.package
   - entries:
-      - name: trustee-operator.v1.1.0
-        replaces: trustee-operator.v1.0.0
-        skipRange: '>=0.1.0 <1.1.0'
+      - name: trustee-operator.v1.2.0
+        replaces: trustee-operator.v1.1.0
+        skipRange: '>=0.1.0 <1.2.0'
     name: stable
     package: trustee-operator
     schema: olm.channel
-  - image: registry.redhat.io/build-of-trustee/trustee-operator-bundle@sha256:54bf1ee5c5c8685d399ce869f67a7cb280ccc3035c921f64bcae6a5694d3d921
+  - image: registry.redhat.io/build-of-trustee/trustee-operator-bundle@sha256:e2628ff773dade646168b48ac2519ae46a8ce157fb806db41659fdc6982545c5
     schema: olm.bundle
 schema: olm.template.basic


### PR DESCRIPTION
Updates the test FBC catalog template with the latest trustee-operator-bundle image and triggers the catalog build pipeline.